### PR TITLE
Remove 'event' parameter name from log()

### DIFF
--- a/Sources/Umbrella/Umbrella.swift
+++ b/Sources/Umbrella/Umbrella.swift
@@ -18,7 +18,7 @@ final public class Analytics<Event: EventType> {
     self.providers.append(provider)
   }
 
-  public func log(event: Event) {
+  public func log(_ event: Event) {
     for provider in self.providers {
       guard let eventName = event.name(for: provider) else { continue }
       let parameters = event.parameters(for: provider)

--- a/Tests/UmbrellaTests/UmbrellaTests.swift
+++ b/Tests/UmbrellaTests/UmbrellaTests.swift
@@ -15,7 +15,7 @@ class UmbrellaTests: XCTestCase {
 
   func testAnalytics_singleProvider() {
     self.analytics.register(provider: self.firebaseProvider)
-    self.analytics.log(event: .login(username: "devxoul"))
+    self.analytics.log(.login(username: "devxoul"))
     XCTAssertEqual(self.firebaseProvider.events.count, 1)
     XCTAssertEqual(self.firebaseProvider.events[0].name, "login")
     XCTAssertEqual(self.firebaseProvider.events[0].parameters!.count, 1)
@@ -24,15 +24,15 @@ class UmbrellaTests: XCTestCase {
 
   func testAnalytics_singleProvider_nilName() {
     self.analytics.register(provider: self.fabricProvider)
-    self.analytics.log(event: .purchase(productID: 123, price: 99.9))
+    self.analytics.log(.purchase(productID: 123, price: 99.9))
     XCTAssertEqual(self.fabricProvider.events.count, 0)
   }
 
   func testAnalytics_multipleProvider() {
     self.analytics.register(provider: self.firebaseProvider)
     self.analytics.register(provider: self.fabricProvider)
-    self.analytics.log(event: .login(username: "devxoul"))
-    self.analytics.log(event: .purchase(productID: 123, price: 99.9))
+    self.analytics.log(.login(username: "devxoul"))
+    self.analytics.log(.purchase(productID: 123, price: 99.9))
 
     XCTAssertEqual(self.firebaseProvider.events.count, 2)
     XCTAssertEqual(self.firebaseProvider.events[0].name, "login")


### PR DESCRIPTION
```diff
- analytics.log(event: .signup)
+ analytics.log(.signup)
```
