### PR TITLE
Use PrimitiveType as values of parameter dictionary

### DIFF
--- a/Sources/Umbrella/PrimitiveType.swift
+++ b/Sources/Umbrella/PrimitiveType.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreGraphics
+
+public protocol PrimitiveType {
+}
+
+extension String: PrimitiveType {}
+
+extension Bool: PrimitiveType {}
+
+extension Int: PrimitiveType {}
+extension Int8: PrimitiveType {}
+extension Int16: PrimitiveType {}
+extension Int32: PrimitiveType {}
+extension Int64: PrimitiveType {}
+
+extension UInt: PrimitiveType {}
+extension UInt8: PrimitiveType {}
+extension UInt16: PrimitiveType {}
+extension UInt32: PrimitiveType {}
+extension UInt64: PrimitiveType {}
+
+extension Float: PrimitiveType {}
+extension Double: PrimitiveType {}
+
+extension NSNumber: PrimitiveType {}
+extension CGFloat: PrimitiveType {}
+
+extension Array: PrimitiveType where Element: PrimitiveType {}
+extension Dictionary: PrimitiveType where Value: PrimitiveType {}

--- a/Sources/Umbrella/RuntimeProviderType.swift
+++ b/Sources/Umbrella/RuntimeProviderType.swift
@@ -35,7 +35,7 @@ public extension RuntimeProviderType {
     }
   }
 
-  func log(_ eventName: String, parameters: [String: Any]?) {
+  func log(_ eventName: String, parameters: [String: PrimitiveType]?) {
     guard self.responds else { return }
     if let instance = self.instance {
       _ = instance.perform(self.selector, with: eventName, with: parameters)

--- a/Sources/Umbrella/Umbrella.swift
+++ b/Sources/Umbrella/Umbrella.swift
@@ -5,12 +5,12 @@ public protocol AnalyticsType {
 }
 
 public protocol ProviderType {
-  func log(_ eventName: String, parameters: [String: Any]?)
+  func log(_ eventName: String, parameters: [String: PrimitiveType]?)
 }
 
 public protocol EventType {
   func name(for provider: ProviderType) -> String?
-  func parameters(for provider: ProviderType) -> [String: Any]?
+  func parameters(for provider: ProviderType) -> [String: PrimitiveType]?
 }
 
 open class Analytics<Event: EventType>: AnalyticsType {

--- a/Tests/UmbrellaTests/Fixtures.swift
+++ b/Tests/UmbrellaTests/Fixtures.swift
@@ -1,4 +1,5 @@
 import Umbrella
+import Foundation
 
 enum TestEvent: EventType {
   case login(username: String)
@@ -24,7 +25,7 @@ enum TestEvent: EventType {
     }
   }
 
-  func parameters(for provider: ProviderType) -> [String : Any]? {
+  func parameters(for provider: ProviderType) -> [String: PrimitiveType]? {
     switch self {
     case let .login(username):
       switch provider {
@@ -46,9 +47,9 @@ enum TestEvent: EventType {
 }
 
 class MockProvider: ProviderType {
-  var events: [(name: String, parameters: [String: Any]?)] = []
+  var events: [(name: String, parameters: [String: PrimitiveType]?)] = []
 
-  func log(_ eventName: String, parameters: [String: Any]?) {
+  func log(_ eventName: String, parameters: [String: PrimitiveType]?) {
     self.events.append((name: eventName, parameters: parameters))
   }
 }


### PR DESCRIPTION
## Background

Property `parameters` is defined as `[String: Any]` which means that you can return any type of value. It can cause a human error when an event has an arbitrary type as an associated value. For example:

```swift
enum Month: Int {
  case jan = 1, feb, mar
}

enum MyEvent {
  case selectMonth(Month)
}

extension MyEvent: EventType {
  var parameters: [String: Any]? {
    switch self {
    case let .selectMonth(month):
      // expected: ["month": 3]
      // actual  : ["month": "mar"]
      return ["month": month]
    }
  }
}
```

It would be great if the compiler can warn you.

## Solution

Define a protocol `PrimitiveType` which primitive types such as `Int` or `String` conform to. Use this protocol as a value of `parameters` dictionary so that the compiler can warn you if you return some wrong type.

```diff
  extension MyEvent: EventType {
-   var parameters: [String: Any]? {
+   var parameters: [String: PrimitiveType]? {
      switch self {
      case let .selectMonth(month):
        return ["month": month] // ❌ 'Month' does not conform to protocol 'PrimitiveType'
      }
    }
  }
```
