### PR TITLE
Add AppCenter analytics provider

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     .library(name: "UmbrellaLocalytics", targets: ["UmbrellaLocalytics"]),
     .library(name: "UmbrellaMixpanel", targets: ["UmbrellaMixpanel"]),
     .library(name: "UmbrellaSegment", targets: ["UmbrellaSegment"]),
+    .library(name: "UmbrellaAppCenter", targets: ["UmbrellaAppCenter"]),
   ],
   targets: [
     .target(name: "Umbrella"),
@@ -34,6 +35,7 @@ let package = Package(
     .target(name: "UmbrellaLocalytics", dependencies: ["Umbrella"]),
     .target(name: "UmbrellaMixpanel", dependencies: ["Umbrella"]),
     .target(name: "UmbrellaSegment", dependencies: ["Umbrella"]),
+    .target(name: "UmbrellaAppCenter", dependencies: ["Umbrella"]),
     .testTarget(name: "UmbrellaTests", dependencies: ["Umbrella"]),
     .testTarget(name: "UmbrellaAmplitudeTests", dependencies: ["UmbrellaAmplitude"]),
     .testTarget(name: "UmbrellaAnswersTests", dependencies: ["UmbrellaAnswers"]),
@@ -46,6 +48,7 @@ let package = Package(
     .testTarget(name: "UmbrellaLocalyticsTests", dependencies: ["UmbrellaLocalytics"]),
     .testTarget(name: "UmbrellaMixpanelTests", dependencies: ["UmbrellaMixpanel"]),
     .testTarget(name: "UmbrellaSegmentTests", dependencies: ["UmbrellaSegment"]),
+    .testTarget(name: "UmbrellaAppCenterTests", dependencies: ["UmbrellaAppCenter"]),
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Podfile
+++ b/Podfile
@@ -55,3 +55,8 @@ target 'UmbrellaSegmentTests' do
   platform :ios, '8.0'
   pod 'Analytics'
 end
+
+target 'UmbrellaAppCenterTests' do
+  platform :ios, '9.0'
+  pod 'AppCenter/Analytics'
+end

--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ target 'UmbrellaAppsFlyerTests' do
 end
 
 target 'UmbrellaFacebookTests' do
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   pod 'FacebookSDK'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,28 +27,17 @@ PODS:
     - AppCenter/Core
   - AppCenter/Core (4.1.0)
   - AppsFlyerFramework (6.0.4)
-  - Bolts (1.9.0):
-    - Bolts/AppLinks (= 1.9.0)
-    - Bolts/Tasks (= 1.9.0)
-  - Bolts/AppLinks (1.9.0):
-    - Bolts/Tasks
-  - Bolts/Tasks (1.9.0)
   - Fabric (1.7.12)
-  - FacebookSDK (4.38.0):
-    - Bolts (~> 1.9)
-    - FacebookSDK/CoreKit (= 4.38.0)
-    - FacebookSDK/MarketingKit (= 4.38.0)
-  - FacebookSDK/CoreKit (4.38.0):
-    - Bolts (~> 1.9)
-    - FBSDKCoreKit
-  - FacebookSDK/MarketingKit (4.38.0):
-    - Bolts (~> 1.9)
-    - FacebookSDK/CoreKit
-    - FBSDKMarketingKit
-  - FBSDKCoreKit (4.38.1):
-    - Bolts (~> 1.9)
-  - FBSDKMarketingKit (4.38.0):
-    - FBSDKCoreKit
+  - FacebookSDK (8.2.0):
+    - FacebookSDK/CoreKit (= 8.2.0)
+  - FacebookSDK/CoreKit (8.2.0):
+    - FBSDKCoreKit (~> 8.2.0)
+  - FBSDKCoreKit (8.2.0):
+    - FBSDKCoreKit/Basics (= 8.2.0)
+    - FBSDKCoreKit/Core (= 8.2.0)
+  - FBSDKCoreKit/Basics (8.2.0)
+  - FBSDKCoreKit/Core (8.2.0):
+    - FBSDKCoreKit/Basics
   - Firebase/Analytics (5.9.0):
     - Firebase/Core
   - Firebase/Core (5.9.0):
@@ -130,11 +119,7 @@ SPEC REPOS:
     - Analytics
     - Answers
     - Appboy-iOS-SDK
-    - Bolts
     - Fabric
-    - FacebookSDK
-    - FBSDKCoreKit
-    - FBSDKMarketingKit
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
@@ -151,6 +136,8 @@ SPEC REPOS:
   trunk:
     - AppCenter
     - AppsFlyerFramework
+    - FacebookSDK
+    - FBSDKCoreKit
 
 SPEC CHECKSUMS:
   Amplitude-iOS: df355e2be58972041acde9576a2ae97c217bf941
@@ -159,11 +146,9 @@ SPEC CHECKSUMS:
   Appboy-iOS-SDK: c245f36aafe6e1b5249a8924e598e82e1c233f5d
   AppCenter: 8832b158d17e54845c3b88a91076218f0b07174d
   AppsFlyerFramework: acc30e47ea49a058f4bb9b43cf00e976fd80d1ed
-  Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Fabric: 83595475c4149d220e7a82c2f6b6a00456fd2c4d
-  FacebookSDK: 73f54b8b94e09b05647cdef0af147f470cd3edc6
-  FBSDKCoreKit: 8d47857400e2f5bdea697a80daff882e91c84ef6
-  FBSDKMarketingKit: e609f39d74ab273cf52e2f8b7e8829ed412b2827
+  FacebookSDK: 7aa80d5e6eaf235f492328ad40c36dbc16440e52
+  FBSDKCoreKit: 4afd6ff53d8133a433dbcda44451c9498f8c6ce4
   Firebase: 383fa29aca93e371cab776b48a5c66544d3c2003
   FirebaseAnalytics: 831f1f127f4a75698e9875a87bf7e2668730d953
   FirebaseCore: 2a84b6b325792a4319ef71ee18819dcba08d2fd7
@@ -180,4 +165,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: c02b0a305c1199263a246b4aa196798f491a6aaa
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,6 +23,9 @@ PODS:
     - Appboy-iOS-SDK/Feedback
     - Appboy-iOS-SDK/InAppMessage
     - Appboy-iOS-SDK/NewsFeed
+  - AppCenter/Analytics (4.1.0):
+    - AppCenter/Core
+  - AppCenter/Core (4.1.0)
   - AppsFlyerFramework (6.0.4)
   - Bolts (1.9.0):
     - Bolts/AppLinks (= 1.9.0)
@@ -112,6 +115,7 @@ DEPENDENCIES:
   - Analytics
   - Answers
   - Appboy-iOS-SDK
+  - AppCenter/Analytics
   - AppsFlyerFramework
   - FacebookSDK
   - Firebase/Analytics
@@ -145,6 +149,7 @@ SPEC REPOS:
     - nanopb
     - SDWebImage
   trunk:
+    - AppCenter
     - AppsFlyerFramework
 
 SPEC CHECKSUMS:
@@ -152,6 +157,7 @@ SPEC CHECKSUMS:
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
   Answers: e039c0f14c543da0c0ea42c6790ee267d42b8a32
   Appboy-iOS-SDK: c245f36aafe6e1b5249a8924e598e82e1c233f5d
+  AppCenter: 8832b158d17e54845c3b88a91076218f0b07174d
   AppsFlyerFramework: acc30e47ea49a058f4bb9b43cf00e976fd80d1ed
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Fabric: 83595475c4149d220e7a82c2f6b6a00456fd2c4d
@@ -172,6 +178,6 @@ SPEC CHECKSUMS:
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   SDWebImage: 624d6e296c69b244bcede364c72ae0430ac14681
 
-PODFILE CHECKSUM: 8d00f2692229bec58acb049eca1c679917b0c571
+PODFILE CHECKSUM: c02b0a305c1199263a246b4aa196798f491a6aaa
 
 COCOAPODS: 1.9.3

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ There are several built-in providers.
 * LocalyticsProvider ([Localytics](https://cocoapods.org/pods/Localytics))
 * MixpanelProvider ([Mixpanel](https://cocoapods.org/pods/Mixpanel))
 * SegmentProvider ([Analytics](https://cocoapods.org/pods/Analytics))
+* AppCenterProvider ([AppCenter/Analytics](https://cocoapods.org/pods/AppCenter))
 
 If there's no provider you're looking for, you can [create an issue](https://github.com/devxoul/Umbrella/issues/new) or [create custom providers](#creating-custom-providers). It's also welcomed to create a pull request for missing services 🎉
 

--- a/Sources/Umbrella/RuntimeProviderType.swift
+++ b/Sources/Umbrella/RuntimeProviderType.swift
@@ -1,9 +1,19 @@
 import Foundation
 
 public protocol RuntimeProviderType: ProviderType {
+  associatedtype Parameters = [String: Any]
+  
   var className: String { get }
   var instanceSelectorName: String? { get } // optional
   var selectorName: String { get }
+  
+  func mapParameters(_ parameters: [String: Any]) -> Parameters?
+}
+
+public extension RuntimeProviderType where Parameters == [String: Any] {
+  func mapParameters(_ parameters: [String: Any]) -> Parameters? {
+    return parameters
+  }
 }
 
 public extension RuntimeProviderType {
@@ -37,6 +47,7 @@ public extension RuntimeProviderType {
 
   func log(_ eventName: String, parameters: [String: Any]?) {
     guard self.responds else { return }
+    let parameters = parameters.flatMap(mapParameters)
     if let instance = self.instance {
       _ = instance.perform(self.selector, with: eventName, with: parameters)
     } else {

--- a/Sources/UmbrellaAppCenter/AppCenterProvider.swift
+++ b/Sources/UmbrellaAppCenter/AppCenterProvider.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+#if !COCOAPODS
+import Umbrella
+#endif
+
+open class AppCenterProvider: RuntimeProviderType {
+  public typealias Parameters = [String: String]
+  
+  public let className: String = "MSACAnalytics"
+  public let selectorName: String = "trackEvent:withProperties:"
+
+  public init() {
+  }
+  
+  public func mapParameters(_ parameters: [String : Any]) -> Parameters? {
+    return parameters.mapValues(String.init(describing:))
+  }
+}

--- a/Tests/UmbrellaAppCenterTests/AppCenterProviderTests.swift
+++ b/Tests/UmbrellaAppCenterTests/AppCenterProviderTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import Umbrella
+import UmbrellaAppCenter
+import AppCenterAnalytics
+
+final class AppCenterProviderTests: XCTestCase {
+  func testAppCenterProvider() {
+    let provider = AppCenterProvider()
+    XCTAssertTrue(provider.cls === AppCenterAnalytics.Analytics.self)
+    XCTAssertNil(provider.instance)
+    XCTAssertEqual(provider.selector, #selector(AppCenterAnalytics.Analytics.trackEvent(_:withProperties:) as (String, [String: String]) -> ()))
+    XCTAssertTrue(provider.responds)
+  }
+}

--- a/Tests/UmbrellaFacebookTests/FacebookProviderTests.swift
+++ b/Tests/UmbrellaFacebookTests/FacebookProviderTests.swift
@@ -6,9 +6,9 @@ import FBSDKCoreKit
 final class FacebookProviderTests: XCTestCase {
   func testFacebookProvider() {
     let provider = FacebookProvider()
-    XCTAssertTrue(provider.cls === FBSDKAppEvents.self)
+    XCTAssertTrue(provider.cls === AppEvents.self)
     XCTAssertNil(provider.instance)
-    XCTAssertEqual(provider.selector, #selector(FBSDKAppEvents.logEvent(_:parameters:)))
+    XCTAssertEqual(provider.selector, #selector(AppEvents.logEvent(_:parameters:)))
     XCTAssertTrue(provider.responds)
   }
 }

--- a/Umbrella.podspec
+++ b/Umbrella.podspec
@@ -74,4 +74,9 @@ Pod::Spec.new do |s|
     ss.source_files = "Sources/UmbrellaSegment/*.swift"
     ss.dependency "Umbrella/Core"
   end
+  
+  s.subspec "AppCenter" do |ss|
+    ss.source_files = "Sources/UmbrellaAppCenter/*.swift"
+    ss.dependency "Umbrella/Core"
+  end
 end


### PR DESCRIPTION
This PR adds provider for Microsoft AppCenter analytics. Since AppCenter's API accepts `[String: String]` parameters (not `[String: Any]`) I decided to add associated type to `RuntimeProviderType` and give opportunity to its conformers to map parameters appropriately.